### PR TITLE
fix(deps): back to use caret semver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@actions/core": "~2.0"
+        "@actions/core": "^2.0.3"
       },
       "devDependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "release": "semantic-release"
   },
   "dependencies": {
-    "@actions/core": "~2.0"
+    "@actions/core": "^2.0.3"
   },
   "devDependencies": {
     "@semantic-release/commit-analyzer": "^13.0.1",


### PR DESCRIPTION
I thought using `~x.y.z` style semver prevents dependabot from opening PRs but it's not, so backing to the caret style semver as before in #124.
