### PR TITLE
chore: prepare for ESM-only packages

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const core = require('@actions/core')
+let core
 const { stat } = require('fs')
 const { relative, resolve } = require('path')
 
@@ -39,6 +39,7 @@ async function findManifest(workspace, rdnn) {
 }
 
 async function run () {
+  core = await import('@actions/core')
   const rdnn = core.getInput('rdnn', { required: true })
   const workspace = core.getInput('workspace', { required: true })
 


### PR DESCRIPTION
cc @elementary/web-developers
(I couldn't choose this team from the Reviewers dropdown; probably it does not have write access here)

Same with https://github.com/elementary/action-appcenter-review-checklist/pull/152

This PR aims as a preparation to update:

- `@actions/core` to 3.0.0 or later which is pending at #126
